### PR TITLE
ebpf: Add a maximum bound check

### DIFF
--- a/echo-ebpf/src/main.rs
+++ b/echo-ebpf/src/main.rs
@@ -21,7 +21,7 @@ pub struct Buf {
 #[map]
 pub static mut BUF: PerCpuArray<Buf> = PerCpuArray::with_max_entries(1, 0);
 
-#[tracepoint(name="echo")]
+#[tracepoint(name = "echo")]
 pub fn echo_trace_open(ctx: TracePointContext) -> c_long {
     match try_echo_trace_open(ctx) {
         Ok(ret) => ret,
@@ -34,13 +34,16 @@ fn try_echo_trace_open(ctx: TracePointContext) -> Result<c_long, c_long> {
     // sudo cat /sys/kernel/debug/tracing/events/syscalls/sys_enter_open/format
     const FILENAME_OFFSET: usize = 24;
     let filename_addr: u64 = unsafe { ctx.read_at(FILENAME_OFFSET)? };
-    
+
     // get the map-backed buffer that we're going to use as storage for the filename
     let buf = unsafe { BUF.get_mut(0) }.ok_or(0)?;
 
     // read the filename
     let filename = unsafe {
         let len = bpf_probe_read_user_str(filename_addr as *const u8, &mut buf.buf)?;
+        if len >= LOG_BUF_CAPACITY {
+            return Err(-1);
+        }
         core::str::from_utf8_unchecked(&buf.buf[..len])
     };
 


### PR DESCRIPTION
Before this change, verifier in newer kernels was complaining about
possibility of accessing out of bound memory.

Signed-off-by: Michal Rostecki <vadorovsky@gmail.com>